### PR TITLE
Allow unsubscribe while disconnected

### DIFF
--- a/src/main/java/com/pusher/client/Pusher.java
+++ b/src/main/java/com/pusher/client/Pusher.java
@@ -252,14 +252,8 @@ public class Pusher {
     /**
      * Unsubscribes from a channel using via the name of the channel.
      * @param channelName the name of the channel to be unsubscribed from.
-     *
-     * @throws IllegalStateException if {@link Pusher.getConnection().getState()} is not {@link com.pusher.client.connection.ConnectionState.CONNECTED CONNECTED}
      */
     public void unsubscribe(String channelName) {
-
-        if (connection.getState() != ConnectionState.CONNECTED) {
-            throw new IllegalStateException("Cannot unsubscribe from channel " + channelName + " while not connected");
-        }
 
         channelManager.unsubscribeFrom(channelName);
     }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
@@ -51,11 +51,14 @@ public class ChannelManager implements ConnectionEventListener {
         }
 
         InternalChannel channel = channelNameToChannelMap.remove(channelName);
-        if (channel != null) {
-            connection.sendMessage(channel.toUnsubscribeMessage());
-            channel.updateState(ChannelState.UNSUBSCRIBED);
-        } else {
+        if (channel == null) {
             throw new IllegalArgumentException("Cannot unsubscribe to channel " + channelName + ", no subscription found");
+        }
+
+        channel.updateState(ChannelState.UNSUBSCRIBED);
+
+        if (connection.getState() == ConnectionState.CONNECTED){
+            connection.sendMessage(channel.toUnsubscribeMessage());
         }
     }
 

--- a/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
@@ -52,7 +52,7 @@ public class ChannelManager implements ConnectionEventListener {
 
         InternalChannel channel = channelNameToChannelMap.remove(channelName);
         if (channel == null) {
-            throw new IllegalArgumentException("Cannot unsubscribe to channel " + channelName + ", no subscription found");
+            return;
         }
 
         channel.updateState(ChannelState.UNSUBSCRIBED);

--- a/src/test/java/com/pusher/client/PusherTest.java
+++ b/src/test/java/com/pusher/client/PusherTest.java
@@ -306,17 +306,4 @@ public class PusherTest {
     verify(mockChannelManager).unsubscribeFrom(PUBLIC_CHANNEL_NAME);
     }
 
-    @Test(expected=IllegalStateException.class)
-    public void testUnsubscribeWhenDisconnectedThrowsException() {
-    when(mockConnection.getState()).thenReturn(ConnectionState.DISCONNECTED);
-
-    pusher.unsubscribe(PUBLIC_CHANNEL_NAME);
-    }
-
-    @Test(expected=IllegalStateException.class)
-    public void testUnsubscribeWhenConnectingThrowsException() {
-    when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTING);
-
-    pusher.unsubscribe(PUBLIC_CHANNEL_NAME);
-    }
 }

--- a/src/test/java/com/pusher/client/channel/impl/ChannelManagerTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/ChannelManagerTest.java
@@ -277,11 +277,6 @@ public class ChannelManagerTest {
         channelManager.unsubscribeFrom(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testUnsubscribeWhenNotSubscribedThrowsException() {
-        channelManager.unsubscribeFrom(CHANNEL_NAME);
-    }
-
     @Test
     public void testReceiveMessageAfterUnsubscribeDoesNotPassItToChannel() {
         channelManager.subscribeTo(mockInternalChannel, mockEventListener,


### PR DESCRIPTION
**Allow unsubscribe while disconnected**

Actually Pusher class throws an Exception when trying to unsubscribe from a Channel and the connection state is not CONNECTED. This can lead to issues implementing automatic reconnection because when Pusher.connect() is invoked, the library tries to re-subscribe to previouslly created channels, basically subscribing to a channel which nobody is interested to anymore.

With the proposed change, if the status is not CONNECTED the channel is only removed from the map and it will not re-subscribed again at the next connection attempt.

**Ignore unsubscribe request from not subscribed channels**

Just a small improvement to improve tolerancy against developer mistakes. If for any reason a developer invoke `Pusher.unsubscribe()` twice with the same channel name, the program will not break with an unhandled Exception